### PR TITLE
EZ Encounters support for NebuLibs

### DIFF
--- a/ezencounters/main.lua
+++ b/ezencounters/main.lua
@@ -96,22 +96,7 @@ ezencounters.handle_player_move = function(player_id, x, y, z)
     ezencounters.increment_steps_since_encounter(player_id)
 end
 
-ezencounters.pick_encounter_from_table = function (encounter_table)
-    local total_weight = 0
-    for _, option in ipairs(encounter_table.encounters) do
-        total_weight = total_weight + option.weight
-    end
-    local crawler = math.random() * total_weight
-    for i, option in ipairs(encounter_table.encounters) do
-        crawler = crawler - option.weight
-        if crawler <= 0 then
-            return encounter_table.encounters[i]
-        end
-    end
-    return encounter_table.encounters[1]
-end
-
-ezencounters.pick_freedom_encounter_from_table = function(encounter_table, advantage_string)
+ezencounters.pick_encounter_from_table = function (encounter_table, advantage_string)
     local total_weight = 0
     local encounters = encounter_table.encounters
     if advantage_string == "advantage" then

--- a/ezencounters/main.lua
+++ b/ezencounters/main.lua
@@ -79,12 +79,11 @@ ezencounters.increment_steps_since_encounter = function (player_id)
     end
 end
 
-Net:on("player_move", function(event)
-    local player_id = event.player_id
+ezencounters.handle_player_move = function(player_id, x, y, z)
     local floor = math.floor
-    local rounded_pos_x = floor(event.x)
-    local rounded_pos_y = floor(event.y)
-    local rounded_pos_z = floor(event.z)
+    local rounded_pos_x = floor(x)
+    local rounded_pos_y = floor(y)
+    local rounded_pos_z = floor(z)
     local last_tile = player_last_position[player_id]
     if last_tile then
         if last_tile.x ~= rounded_pos_x or last_tile.y ~= rounded_pos_y or last_tile.z ~= rounded_pos_z then
@@ -95,7 +94,7 @@ Net:on("player_move", function(event)
         player_last_position[player_id] = {x=rounded_pos_x,y=rounded_pos_y,z=rounded_pos_z}
     end
     ezencounters.increment_steps_since_encounter(player_id)
-end)
+end
 
 ezencounters.pick_encounter_from_table = function (encounter_table)
     local total_weight = 0
@@ -190,16 +189,12 @@ Net:on("battle_results", function(event)
     -- stats = { health: number, score: number, time: number, ran: bool, emotion: number, turns: number, npcs: { id: String, health: number }[] }
 end)
 
-Net:on("player_area_transfer", function(event)
-    local player_id = event.player_id
-    ezencounters.clear_last_position(player_id)
-end)
+ezencounters.handle_player_transfer = ezencounters.clear_last_position
 
-Net:on("player_disconnect", function(event)
-    local player_id = event.player_id
+ezencounters.handle_player_disconnect = function (player_id)
     encounter_finished_callbacks[player_id] = nil
     ezencounters.clear_last_position(player_id)
-end)
+end
 
 local function on_radius_encounter_triggered(event)
     return async(function ()


### PR DESCRIPTION
This one small edit to the command command allows NebuLibs to use ezencounters for its battles. Everything else is handled from the plugin's end.

I've already tested that this does not affect regular usage of EZ Encters, _and it doesn't!_ They run just fine.