### PR TITLE
NebuLibs support

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -55,6 +55,14 @@ function helpers.clear_table(tbl)
     end
 end
 
+function helpers.shallow_copy(tbl)
+    local t2 = {}
+    for k,v in pairs(tbl) do
+      t2[k] = v
+    end
+    return t2
+  end
+
 function helpers.split(string, delimiter)
     local table = {}
     for tag, line in string:gmatch('([^' .. delimiter .. ']+)') do


### PR DESCRIPTION
So let's talk about this change.

+It adds the ability to support multiple encounter positions from outside ezencounters, for instance NebuLibs, but in order to do so I had to convert the positions argument in to a full table. This meant modifying your code some to allow for randomized picking of positions, and adding a shallow copy tool to helpers so that I don't alter the original file in memory.

+It also adds detection for different encounter tables based on NebuLibs tile terrain strings while leaving other encounters alone by defaulting to just scanning the "encounters" instead of anything else. However, this is very useful for NebuLibs, and in theory for any freedom mission content someone wishes to start making.

Ultimately this does break every area encounter lua file by requiring a restructure of how enemy positions are put in place. But I figure since we're breaking things...

Maybe it won't be so bad.